### PR TITLE
ServerEvent added to provide internal Event Loop

### DIFF
--- a/Event/ServerEvent.php
+++ b/Event/ServerEvent.php
@@ -1,0 +1,21 @@
+<?php
+namespace JDare\ClankBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use \React\EventLoop\LoopInterface;
+
+class ServerEvent extends Event
+{
+    protected $loop;
+
+    public function __construct(LoopInterface $loop) {
+        $this->loop = $loop;
+    }
+
+    /**
+     * Get Server Event Loop to add other services in the same loop.
+     */
+    public function getEventLoop() {
+        return $this->loop;
+    }
+}

--- a/Server/Type/WebSocketServerType.php
+++ b/Server/Type/WebSocketServerType.php
@@ -59,8 +59,6 @@ class WebSocketServerType implements ServerTypeInterface
         $this->setupPeriodicServices();
 
         $this->server = new \Ratchet\Server\IoServer($this->app, $this->socket, $this->loop);
-        
-
     }
 
     private function setupPeriodicServices()

--- a/Server/Type/WebSocketServerType.php
+++ b/Server/Type/WebSocketServerType.php
@@ -3,9 +3,9 @@
 namespace JDare\ClankBundle\Server\Type;
 
 use JDare\ClankBundle\Periodic\PeriodicInterface;
+use JDare\ClankBundle\Event\ServerEvent;
 use Ratchet\WebSocket\WsServer;
 use Ratchet\Wamp\WampServer;
-
 use Ratchet\Session\SessionProvider;
 
 class WebSocketServerType implements ServerTypeInterface
@@ -20,10 +20,18 @@ class WebSocketServerType implements ServerTypeInterface
 
         $this->periodicServices = array();
     }
+    
+    public function getLoop() {
+        return $this->loop;
+    }
 
     public function launch()
     {
         $this->setupServer();
+        
+        /* Server Event Loop to add other services in the same loop. */
+        $event = new ServerEvent($this->loop);
+        $this->container->get("event_dispatcher")->dispatch("clank.server.launched", $event);        
 
         $this->loop->run();
     }
@@ -38,7 +46,7 @@ class WebSocketServerType implements ServerTypeInterface
         /** @var $loop \React\EventLoop\LoopInterface */
 
         $this->loop = \React\EventLoop\Factory::create();
-
+        
         $this->socket = new \React\Socket\Server($this->loop);
 
         if ($this->host)
@@ -50,8 +58,9 @@ class WebSocketServerType implements ServerTypeInterface
 
         $this->setupPeriodicServices();
 
-
         $this->server = new \Ratchet\Server\IoServer($this->app, $this->socket, $this->loop);
+        
+
     }
 
     private function setupPeriodicServices()


### PR DESCRIPTION
Hi JDare ;) 

Thanks for your great efforts to publish and maintain this bundle. It's saves me a lot of time and it has a nice Symfony2 implementation. I tried to make a push integration from the server using a MessageQueuer like Redis. (As Ratchet did in their examples) but I prefere to extend/use the ClankBundle. 

In order to run a service in the same eventloop, I think we need a way to expose the eventloop object. I made a ServerEvent triggered by the server launch method. It only contains the loop (but thats enough) so I can add extra services in a separated listener in my own bundles. I made a test with a Redis Pub/Sub client in the listener and it works like a charm.

When you agree with this pull request I'll also make an example in the manual for a push service with a MQer or something similar. 
