### PR TITLE
EventDispatcherInterface - Fix for Symfony 2.4

### DIFF
--- a/Server/App/ClankApp.php
+++ b/Server/App/ClankApp.php
@@ -7,7 +7,7 @@ use Ratchet\Wamp\WampServerInterface;
 
 use JDare\ClankBundle\Server\App\Handler\RPCHandlerInterface;
 use JDare\ClankBundle\Server\App\Handler\TopicHandlerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use JDare\ClankBundle\Event\ClientEvent;
 use JDare\ClankBundle\Event\ClientErrorEvent;
 
@@ -15,7 +15,7 @@ class ClankApp implements WampServerInterface {
 
     protected $topicHandler, $rpcHandler, $eventDispatcher;
 
-    public function __construct(RPCHandlerInterface $rpcHandler, TopicHandlerInterface $topicHandler, EventDispatcher $eventDispatcher)
+    public function __construct(RPCHandlerInterface $rpcHandler, TopicHandlerInterface $topicHandler, EventDispatcherInterface $eventDispatcher)
     {
         $this->rpcHandler = $rpcHandler;
         $this->topicHandler = $topicHandler;


### PR DESCRIPTION
EventDispatcher > EventDispatcherInterface

Background:

php app/console clank:server

Catchable Fatal Error: Argument 3 passed to JDare\ClankBundle\Server\App\ClankApp::__construct() must be an instance of Symfony\Component\EventDispatcher\EventDispatcher, instance of Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher given
