### PR TITLE
automatic unsubscription on connection close

### DIFF
--- a/Server/App/ClankApp.php
+++ b/Server/App/ClankApp.php
@@ -46,6 +46,10 @@ class ClankApp implements WampServerInterface {
     public function onClose(Conn $conn) {
         $event = new ClientEvent($conn, ClientEvent::$disconnected);
         $this->eventDispatcher->dispatch("clank.client.disconnected", $event);
+        foreach ($conn->WAMP->subscriptions as $subscription) {
+            $this->onUnSubscribe($conn, $subscription);
+            $subscription->remove($conn);
+        }
     }
 
     public function onError(Conn $conn, \Exception $e) {


### PR DESCRIPTION
When a connection is closed force call unsubscribe event on all topics subscribed and remove connection from subscriptions.
